### PR TITLE
Revert to integer for now

### DIFF
--- a/technologie-architectuur.md
+++ b/technologie-architectuur.md
@@ -1890,7 +1890,7 @@ CareTeam \(Other\)
 | **CarePlanActivityStatus.percentageCompleted** |  |
 | Definition | An indication of the progress made on the CarePlanActivity. |
 | Control | 0..1 |
-| Type | decimal |
+| Type | integer |
 | Extension | http://ggz.koppeltaal.nl/fhir/Koppeltaal/CarePlanActivityStatus\#PercentageCompleted |
 | **CarePlanActivityStatus.blackBoxState** |  |
 | Definition | BlackBoxState allows applications using Koppeltaal to extend messages with information that is not necessarily understood by other applications. The application including BlackBoxState must subscribe to the message to which the BlackBoxState is attached, allowing the application to reload the BlackBoxState next time the application starts for a certain user. BlackBoxState is implemented using the FHIR extension mechanism. Extensions can be nested. For an example, look at how the ProcessingStatus extension is defined for the MessageHeader resource. Applications using BlackBoxState must create a FHIR profile that describes their extension\(s\). |


### PR DESCRIPTION
Updating the documentation to define `percentageCompleted` was a bit premature. I propose to revert to `integer` as not to make the matter more confusing.